### PR TITLE
Fix salary calculation logic in addSalarySheet and addSalarySheetBulk…

### DIFF
--- a/src/controllers/salary.controller.js
+++ b/src/controllers/salary.controller.js
@@ -95,7 +95,7 @@ const addSalarySheet = handleAsync(async (req, res) => {
       salaryCalculated = salary;
       break;
     default:
-      salaryCalculated = salary - oneDaySalary * absentDays;
+      salaryCalculated = salary + oneDaySalary - oneDaySalary * absentDays;
       break;
   }
   const salaryBeforeTax = salaryCalculated - kidFee + oldDue - advance;
@@ -213,7 +213,8 @@ const addSalarySheetBulk = handleAsync(async (req, res) => {
         salaryCalculated = salary;
         break;
       default:
-        salaryCalculated = salary - oneDaySalary * item.absentDays;
+        salaryCalculated =
+          salary + oneDaySalary - oneDaySalary * item.absentDays;
         break;
     }
     const salaryBeforeTax =
@@ -414,7 +415,7 @@ const updateSalarySheet = handleAsync(async (req, res) => {
       salaryCalculated = salary;
       break;
     default:
-      salaryCalculated = salary - oneDaySalary * absentDays;
+      salaryCalculated = salary + oneDaySalary - oneDaySalary * absentDays;
       break;
   }
 


### PR DESCRIPTION
This pull request includes changes to the salary calculation logic in the `salary.controller.js` file to correct the formula used for calculating the salary when there are absent days. The changes ensure that an additional day's salary is added before subtracting the salary for the absent days.

Changes to salary calculation logic:

* [`src/controllers/salary.controller.js`](diffhunk://#diff-dd6c5f2aa31f537ba5d227784c196e5bf0f01673a328dad5083f53a7f571c134L98-R98): Modified the salary calculation formula in the `addSalarySheet` function to add one day's salary before subtracting the absent days' salary.
* [`src/controllers/salary.controller.js`](diffhunk://#diff-dd6c5f2aa31f537ba5d227784c196e5bf0f01673a328dad5083f53a7f571c134L216-R217): Updated the salary calculation formula in the `addSalarySheetBulk` function to follow the same logic as the `addSalarySheet` function.
* [`src/controllers/salary.controller.js`](diffhunk://#diff-dd6c5f2aa31f537ba5d227784c196e5bf0f01673a328dad5083f53a7f571c134L417-R418): Adjusted the salary calculation formula in the `updateSalarySheet` function to add one day's salary before subtracting the absent days' salary.… functions for accuracy